### PR TITLE
Fix issue#33: 油圧表示桁あふれの対策

### DIFF
--- a/Firmware/src/dataregister.c
+++ b/Firmware/src/dataregister.c
@@ -85,7 +85,7 @@ void data_store(void)
 	if(g_CALC_data.num4 > 32767) g_CALC_data.num4 = g_CALC_data.num4 -65534;
 	smooth(g_CALC_data_sm.num4,0.3, g_CALC_data.num4);
 
-	g_CALC_data.num5 = (float)((((unsigned int)rx_dataframe4.data[0]) << 8) + rx_dataframe4.data[1]) * 0.1   ; // OIL Pressure
+	g_CALC_data.num5 = (float)((((unsigned int)rx_dataframe4.data[0]) << 8) + rx_dataframe4.data[1]) * 0.001 ; // OIL Pressure
 	if(g_CALC_data.num5 > 32767) g_CALC_data.num5 = g_CALC_data.num5 -65534;
 	smooth(g_CALC_data_sm.num5,0.1, g_CALC_data.num5);
 


### PR DESCRIPTION
油圧計算の係数を0.1から0.001に変更し、表示側で100することで、
3桁表示のまま最大999100=99900kPaまで対応可能にした。

- 油圧計算係数: 0.1  0.001
- CANデータ値  0.001 = 内部値（1/100）
- 内部値  100 = 表示値（正しいkPa値）

Closes #33
