### PR TITLE
fix: ODO/TRIP値が再起動時に破損するバグを修正

### DIFF
--- a/Firmware/src/param_console.c
+++ b/Firmware/src/param_console.c
@@ -423,6 +423,14 @@ static void parse_command(const char *line)
         cmd_trip_reset();
     } else if (strcmp(cmd, "fwupdate") == 0) {
         cmd_fwupdate();
+    } else if (strcmp(cmd, "debug_eeprom") == 0) {
+        /* レガシー領域(0x0000)の生データを表示 */
+        extern void debug_dump_legacy_eeprom(void);
+        debug_dump_legacy_eeprom();
+    } else if (strcmp(cmd, "wr_cnt_reset") == 0) {
+        extern void param_storage_reset_wr_cnt(void);
+        param_storage_reset_wr_cnt();
+        param_console_print("wr_cnt reset to 0.\r\n");
     } else if (strcmp(cmd, "exit") == 0) {
         param_console_print("Exiting parameter mode...\r\n");
         exit_flag = true;


### PR DESCRIPTION
## 概要

ODO/TRIP値が再起動時に古い値に戻ってしまうバグを修正

## 変更点

- `save_legacy_eeprom()`関数を追加し、`odo_init`実行時にレガシーEEPROM(0x0000)にも保存するように修正
- main.cと完全に同じ形式（14バイト送信）でEEPROMに書き込むように修正
- `debug_eeprom`コマンドを追加（EEPROMの内容をデバッグ用にダンプ）
- `wr_cnt_reset`コマンドを追加（書き込みカウンタをリセット）

## 影響範囲

- Firmware/src/param_storage.c - レガシーEEPROM保存機能の追加
- Firmware/src/param_console.c - デバッグコマンドの追加

## テスト

- `odo_init 184578`実行後、再起動してもODO値が正しく維持されることを確認
- `wr_cnt_reset`後、再起動してもwr_cnt=0が維持されることを確認
- `debug_eeprom`コマンドでEEPROMの内容が正しく表示されることを確認

## 関連Issue

- なし（ユーザー報告によるバグ修正）