### PR TITLE
feat(#65): Phase2 - CAN Configuration UI with input validation

### DIFF
--- a/Firmware/src/can.h
+++ b/Firmware/src/can.h
@@ -55,7 +55,7 @@ enum app_err_enum {    APP_NO_ERR 			= 0x00,
 					   /* Add your application errors/alarms here. */
                   };
 
-/* CAN channel numbers */				  
+/* CAN channel numbers */
 enum CAN_channel_num {	CH_0 = 0,
 						CH_1 = 1,
 						CH_2 = 2
@@ -65,11 +65,11 @@ enum CAN_channel_num {	CH_0 = 0,
 enum CAN_mailbox_mode {  CANBOX_NORMAL = 0,
                          CANBOX_FIFO   = 1,
                       };
-						
+
 /***********************************************************************************************************************
 Macro definitions
 ***********************************************************************************************************************/
-/* Mailboxes used for demo. Keep mailboxes 4 apart if you want masks 
+/* Mailboxes used for demo. Keep mailboxes 4 apart if you want masks
 independent - not affecting neighboring mailboxes. */
 #define 	CANBOX_TX		    (0x00)      /* First mailbox */
 //#define 	CANBOX_RX 		    (0x04)
@@ -120,6 +120,7 @@ extern enum app_err_enum	app_err_nr;
 uint32_t reset_all_errors(uint8_t g_can_channel);
 void Init_CAN(void);
 void main_CAN(void);
+void can_update_rx_filters(void);  /* Issue #65: CAN受信フィルタ更新 */
 
 #endif //API_DEMO_H
 /* file end */

--- a/HostApp/FULLMONI-WIDE-Terminal/MainWindow.xaml
+++ b/HostApp/FULLMONI-WIDE-Terminal/MainWindow.xaml
@@ -8,7 +8,7 @@
         xmlns:views="clr-namespace:FullmoniTerminal.Views"
         mc:Ignorable="d"
         Title="FULLMONI-WIDE Terminal"
-        Height="640" Width="480"
+        Height="640" Width="530"
         ResizeMode="CanMinimize"
         FontFamily="Meiryo UI"
         Background="{DynamicResource BackgroundGradient}"
@@ -90,7 +90,7 @@
         </Border>
 
         <!-- タブコントロール -->
-        <TabControl Grid.Row="1" Margin="0,0,0,6" SelectedIndex="4">
+        <TabControl Grid.Row="1" Margin="0,0,0,6" SelectedIndex="5">
             <!-- タブ1: ステータス -->
             <TabItem Header="ステータス" IsEnabled="{Binding IsFirmwareMode}">
                 <Grid Margin="8">
@@ -343,7 +343,165 @@
                 </Grid>
             </TabItem>
 
-            <!-- タブ3: 起動画面変更 -->
+            <!-- タブ3: CAN設定 -->
+            <TabItem Header="CAN設定" IsEnabled="{Binding IsFirmwareMode}">
+                <Grid Margin="8">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <!-- CANチャンネル設定 -->
+                    <Border Grid.Row="0" Background="{DynamicResource CardBackgroundBrush}" CornerRadius="4" Padding="10" Margin="0,0,0,8">
+                        <StackPanel>
+                            <TextBlock Text="受信チャンネル設定" FontWeight="Bold" FontSize="12" Margin="0,0,0,8" Foreground="{DynamicResource TextBrush}"/>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="35"/>
+                                    <ColumnDefinition Width="80"/>
+                                    <ColumnDefinition Width="40"/>
+                                    <ColumnDefinition Width="20"/>
+                                    <ColumnDefinition Width="35"/>
+                                    <ColumnDefinition Width="80"/>
+                                    <ColumnDefinition Width="40"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+
+                                <!-- CH1-2 -->
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="CH1" FontSize="11" VerticalAlignment="Center" Foreground="{DynamicResource TextBrush}"/>
+                                <TextBox Grid.Row="0" Grid.Column="1" x:Name="CanCh1IdBox" Text="0x3E8" Height="22" FontSize="11" Margin="2" IsEnabled="{Binding IsOperationEnabled}"/>
+                                <CheckBox Grid.Row="0" Grid.Column="2" x:Name="CanCh1EnabledBox" IsChecked="True" VerticalAlignment="Center" HorizontalAlignment="Center" IsEnabled="{Binding IsOperationEnabled}"/>
+                                <TextBlock Grid.Row="0" Grid.Column="4" Text="CH2" FontSize="11" VerticalAlignment="Center" Foreground="{DynamicResource TextBrush}"/>
+                                <TextBox Grid.Row="0" Grid.Column="5" x:Name="CanCh2IdBox" Text="0x3E9" Height="22" FontSize="11" Margin="2" IsEnabled="{Binding IsOperationEnabled}"/>
+                                <CheckBox Grid.Row="0" Grid.Column="6" x:Name="CanCh2EnabledBox" IsChecked="True" VerticalAlignment="Center" HorizontalAlignment="Center" IsEnabled="{Binding IsOperationEnabled}"/>
+
+                                <!-- CH3-4 -->
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="CH3" FontSize="11" VerticalAlignment="Center" Foreground="{DynamicResource TextBrush}"/>
+                                <TextBox Grid.Row="1" Grid.Column="1" x:Name="CanCh3IdBox" Text="0x3EA" Height="22" FontSize="11" Margin="2" IsEnabled="{Binding IsOperationEnabled}"/>
+                                <CheckBox Grid.Row="1" Grid.Column="2" x:Name="CanCh3EnabledBox" IsChecked="True" VerticalAlignment="Center" HorizontalAlignment="Center" IsEnabled="{Binding IsOperationEnabled}"/>
+                                <TextBlock Grid.Row="1" Grid.Column="4" Text="CH4" FontSize="11" VerticalAlignment="Center" Foreground="{DynamicResource TextBrush}"/>
+                                <TextBox Grid.Row="1" Grid.Column="5" x:Name="CanCh4IdBox" Text="0x3EB" Height="22" FontSize="11" Margin="2" IsEnabled="{Binding IsOperationEnabled}"/>
+                                <CheckBox Grid.Row="1" Grid.Column="6" x:Name="CanCh4EnabledBox" IsChecked="True" VerticalAlignment="Center" HorizontalAlignment="Center" IsEnabled="{Binding IsOperationEnabled}"/>
+
+                                <!-- CH5-6 -->
+                                <TextBlock Grid.Row="2" Grid.Column="0" Text="CH5" FontSize="11" VerticalAlignment="Center" Foreground="{DynamicResource TextBrush}"/>
+                                <TextBox Grid.Row="2" Grid.Column="1" x:Name="CanCh5IdBox" Text="0x3EC" Height="22" FontSize="11" Margin="2" IsEnabled="{Binding IsOperationEnabled}"/>
+                                <CheckBox Grid.Row="2" Grid.Column="2" x:Name="CanCh5EnabledBox" IsChecked="True" VerticalAlignment="Center" HorizontalAlignment="Center" IsEnabled="{Binding IsOperationEnabled}"/>
+                                <TextBlock Grid.Row="2" Grid.Column="4" Text="CH6" FontSize="11" VerticalAlignment="Center" Foreground="{DynamicResource TextBrush}"/>
+                                <TextBox Grid.Row="2" Grid.Column="5" x:Name="CanCh6IdBox" Text="0x3ED" Height="22" FontSize="11" Margin="2" IsEnabled="{Binding IsOperationEnabled}"/>
+                                <CheckBox Grid.Row="2" Grid.Column="6" x:Name="CanCh6EnabledBox" IsChecked="False" VerticalAlignment="Center" HorizontalAlignment="Center" IsEnabled="{Binding IsOperationEnabled}"/>
+                            </Grid>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- データフィールド定義 -->
+                    <Border Grid.Row="1" Background="{DynamicResource CardBackgroundBrush}" CornerRadius="4" Padding="10">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+
+                            <TextBlock Grid.Row="0" Text="データフィールド定義 (最大8個)" FontWeight="Bold" FontSize="12" Margin="0,0,0,8" Foreground="{DynamicResource TextBrush}"/>
+
+                            <DataGrid Grid.Row="1" x:Name="CanFieldsGrid"
+                                      AutoGenerateColumns="False"
+                                      CanUserAddRows="False"
+                                      CanUserDeleteRows="False"
+                                      HeadersVisibility="Column"
+                                      GridLinesVisibility="Horizontal"
+                                      Background="Transparent"
+                                      RowBackground="{DynamicResource CardBackgroundBrush}"
+                                      AlternatingRowBackground="{DynamicResource PrimaryBackgroundBrush}"
+                                      Foreground="{DynamicResource TextBrush}"
+                                      BorderBrush="{DynamicResource BorderBrush}"
+                                      FontSize="11"
+                                      IsEnabled="{Binding IsOperationEnabled}">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Header="#" Binding="{Binding Index}" Width="25" IsReadOnly="True"/>
+                                    <DataGridTextColumn Header="CH" Binding="{Binding Channel}" Width="35"/>
+                                    <DataGridTextColumn Header="Byte" Binding="{Binding StartByte}" Width="40"/>
+                                    <DataGridTextColumn Header="Size" Binding="{Binding ByteCount}" Width="40"/>
+                                    <DataGridComboBoxColumn Header="Type" SelectedItemBinding="{Binding DataType}" Width="45">
+                                        <DataGridComboBoxColumn.ElementStyle>
+                                            <Style TargetType="ComboBox">
+                                                <Setter Property="ItemsSource" Value="{Binding DataContext.DataTypeOptions, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>
+                                            </Style>
+                                        </DataGridComboBoxColumn.ElementStyle>
+                                        <DataGridComboBoxColumn.EditingElementStyle>
+                                            <Style TargetType="ComboBox">
+                                                <Setter Property="ItemsSource" Value="{Binding DataContext.DataTypeOptions, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>
+                                            </Style>
+                                        </DataGridComboBoxColumn.EditingElementStyle>
+                                    </DataGridComboBoxColumn>
+                                    <DataGridComboBoxColumn Header="End" SelectedItemBinding="{Binding Endian}" Width="40">
+                                        <DataGridComboBoxColumn.ElementStyle>
+                                            <Style TargetType="ComboBox">
+                                                <Setter Property="ItemsSource" Value="{Binding DataContext.EndianOptions, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>
+                                            </Style>
+                                        </DataGridComboBoxColumn.ElementStyle>
+                                        <DataGridComboBoxColumn.EditingElementStyle>
+                                            <Style TargetType="ComboBox">
+                                                <Setter Property="ItemsSource" Value="{Binding DataContext.EndianOptions, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>
+                                            </Style>
+                                        </DataGridComboBoxColumn.EditingElementStyle>
+                                    </DataGridComboBoxColumn>
+                                    <DataGridComboBoxColumn Header="Var" SelectedItemBinding="{Binding TargetVarName}" Width="55">
+                                        <DataGridComboBoxColumn.ElementStyle>
+                                            <Style TargetType="ComboBox">
+                                                <Setter Property="ItemsSource" Value="{Binding DataContext.VarOptions, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>
+                                            </Style>
+                                        </DataGridComboBoxColumn.ElementStyle>
+                                        <DataGridComboBoxColumn.EditingElementStyle>
+                                            <Style TargetType="ComboBox">
+                                                <Setter Property="ItemsSource" Value="{Binding DataContext.VarOptions, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>
+                                            </Style>
+                                        </DataGridComboBoxColumn.EditingElementStyle>
+                                    </DataGridComboBoxColumn>
+                                    <DataGridTextColumn Header="Off" Binding="{Binding Offset}" Width="40"/>
+                                    <DataGridTextColumn Header="Mul" Binding="{Binding Multiplier}" Width="50"/>
+                                    <DataGridTextColumn Header="Div" Binding="{Binding Divisor}" Width="50"/>
+                                    <DataGridCheckBoxColumn Header="EN" Binding="{Binding Enabled}" Width="35"/>
+                                </DataGrid.Columns>
+                            </DataGrid>
+
+                            <TextBlock Grid.Row="2" Text="Type: U=Unsigned, S=Signed | End: B=Big, L=Little | Mul/Div: 1000=x1.0"
+                                       FontSize="10" Foreground="{DynamicResource TextMutedBrush}" Margin="0,6,0,0"/>
+                        </Grid>
+                    </Border>
+
+                    <!-- ボタンとステータス -->
+                    <StackPanel Grid.Row="2" Margin="0,8,0,0">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <Button Content="読込" Width="70" Height="26" FontSize="12" Margin="0,0,6,0"
+                                    Style="{DynamicResource PrimaryButton}"
+                                    Click="CanReadButton_Click"
+                                    IsEnabled="{Binding IsOperationEnabled}"/>
+                            <Button Content="書込" Width="70" Height="26" FontSize="12" Margin="0,0,6,0"
+                                    Style="{DynamicResource SuccessButton}"
+                                    Click="CanWriteButton_Click"
+                                    IsEnabled="{Binding IsOperationEnabled}"/>
+                            <Button Content="デフォルト" Width="70" Height="26" FontSize="12"
+                                    Style="{DynamicResource SecondaryButton}"
+                                    Click="CanDefaultButton_Click"
+                                    IsEnabled="{Binding IsOperationEnabled}"/>
+                        </StackPanel>
+                        <!-- ステータス表示 -->
+                        <Border Background="{DynamicResource PrimaryBackgroundBrush}" CornerRadius="3" Margin="0,8,0,0" Padding="6">
+                            <TextBlock x:Name="CanStatusText" Text="ボタンを押すとコマンドが送信されます"
+                                       FontSize="11" Foreground="{DynamicResource TextMutedBrush}" TextWrapping="Wrap"/>
+                        </Border>
+                    </StackPanel>
+                </Grid>
+            </TabItem>
+
+            <!-- タブ4: 起動画面変更 -->
             <TabItem Header="起動画面変更" IsEnabled="{Binding IsFirmwareMode}">
                 <views:StartupImageView DataContext="{Binding StartupImageViewModel}" />
             </TabItem>

--- a/HostApp/FULLMONI-WIDE-Terminal/MainWindow.xaml.cs
+++ b/HostApp/FULLMONI-WIDE-Terminal/MainWindow.xaml.cs
@@ -1,18 +1,235 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
 
 namespace FullmoniTerminal;
 
 /// <summary>
+/// ComboBox選択肢用のDataContext
+/// </summary>
+public class CanFieldsContext
+{
+    public ObservableCollection<CanFieldItem> Fields { get; set; } = new();
+    public List<string> DataTypeOptions { get; } = new() { "U", "S" };
+    public List<string> EndianOptions { get; } = new() { "B", "L" };
+    public List<string> VarOptions { get; } = new() { "REV", "AF", "NUM1", "NUM2", "NUM3", "NUM4", "NUM5", "NUM6", "SPEED" };
+}
+
+/// <summary>
+/// CANフィールド定義のデータモデル
+/// </summary>
+public class CanFieldItem : INotifyPropertyChanged
+{
+    private int _index;
+    private int _channel = 1;
+    private int _startByte = 0;
+    private int _byteCount = 2;
+    private string _dataType = "U";
+    private string _endian = "B";
+    private int _targetVar = 0;
+    private int _offset = 0;
+    private int _multiplier = 1000;
+    private int _divisor = 1000;
+    private bool _enabled = false;
+
+    // 変数名リスト（TargetVarNameプロパティで使用）
+    private static readonly string[] VarNames = { "REV", "AF", "NUM1", "NUM2", "NUM3", "NUM4", "NUM5", "NUM6", "SPEED" };
+
+    public int Index { get => _index; set { _index = value; OnPropertyChanged(nameof(Index)); } }
+    public int Channel { get => _channel; set { _channel = value; OnPropertyChanged(nameof(Channel)); } }
+    public int StartByte { get => _startByte; set { _startByte = value; OnPropertyChanged(nameof(StartByte)); } }
+    public int ByteCount { get => _byteCount; set { _byteCount = value; OnPropertyChanged(nameof(ByteCount)); } }
+    public string DataType { get => _dataType; set { _dataType = value; OnPropertyChanged(nameof(DataType)); } }
+    public string Endian { get => _endian; set { _endian = value; OnPropertyChanged(nameof(Endian)); } }
+    public int TargetVar { get => _targetVar; set { _targetVar = value; OnPropertyChanged(nameof(TargetVar)); OnPropertyChanged(nameof(TargetVarName)); } }
+    
+    // ComboBox用: 変数名で表示・選択
+    public string TargetVarName
+    {
+        get => (_targetVar >= 0 && _targetVar < VarNames.Length) ? VarNames[_targetVar] : "REV";
+        set
+        {
+            for (int i = 0; i < VarNames.Length; i++)
+            {
+                if (VarNames[i] == value)
+                {
+                    TargetVar = i;
+                    return;
+                }
+            }
+            TargetVar = 0; // デフォルト
+        }
+    }
+    
+    public int Offset { get => _offset; set { _offset = value; OnPropertyChanged(nameof(Offset)); } }
+    public int Multiplier { get => _multiplier; set { _multiplier = value; OnPropertyChanged(nameof(Multiplier)); } }
+    public int Divisor { get => _divisor; set { _divisor = value; OnPropertyChanged(nameof(Divisor)); } }
+    public bool Enabled { get => _enabled; set { _enabled = value; OnPropertyChanged(nameof(Enabled)); } }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    protected void OnPropertyChanged(string propertyName)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}
+
+/// <summary>
 /// Interaction logic for MainWindow.xaml
 /// </summary>
 public partial class MainWindow : Window
 {
+    private ObservableCollection<CanFieldItem> _canFields = new();
+    private CanFieldsContext _canFieldsContext = new();
+
     public MainWindow()
     {
         InitializeComponent();
+        InitializeCanFields();
+    }
+
+    // 変数名 → 数値インデックス変換テーブル
+    private static readonly Dictionary<string, int> VarNameToIndex = new(StringComparer.OrdinalIgnoreCase)
+    {
+        { "REV", 0 },
+        { "AF", 1 },
+        { "NUM1", 2 },
+        { "NUM2", 3 },
+        { "NUM3", 4 },
+        { "NUM4", 5 },
+        { "NUM5", 6 },
+        { "NUM6", 7 },
+        { "SPEED", 8 },
+        { "---", 255 }
+    };
+
+    // 数値インデックス → 変数名変換テーブル
+    private static readonly string[] VarIndexToName = { "REV", "AF", "NUM1", "NUM2", "NUM3", "NUM4", "NUM5", "NUM6", "SPEED" };
+
+    private void InitializeCanFields()
+    {
+        _canFields = new ObservableCollection<CanFieldItem>();
+        _canFieldsContext = new CanFieldsContext { Fields = _canFields };
+
+        // MoTeC M100デフォルト設定 (ファームウェアのCAN_PRESET_MOTECと同じ)
+        // Var: 0=REV, 1=AF, 2=NUM1(水温), 3=NUM2(吸気温), 4=NUM3(油温), 5=NUM4(MAP), 6=NUM5(油圧), 7=NUM6(電圧), 8=SPEED
+        var defaults = new[]
+        {
+            // CH1 (0x3E8): RPM(0-1), MAP(4-5), IAT(6-7)
+            new { Ch = 1, Byte = 0, Size = 2, Type = "U", End = "B", Var = 0, Mul = 1000, Div = 1000, En = true },    // REV
+            new { Ch = 1, Byte = 4, Size = 2, Type = "U", End = "B", Var = 5, Mul = 1000, Div = 10000, En = true },   // NUM4 (MAP)
+            new { Ch = 1, Byte = 6, Size = 2, Type = "S", End = "B", Var = 3, Mul = 1000, Div = 10000, En = true },   // NUM2 (IAT)
+            // CH2 (0x3E9): ECT(0-1), AFR(2-3)
+            new { Ch = 2, Byte = 0, Size = 2, Type = "S", End = "B", Var = 2, Mul = 1000, Div = 10000, En = true },   // NUM1 (WaterTemp)
+            new { Ch = 2, Byte = 2, Size = 2, Type = "U", End = "B", Var = 1, Mul = 147, Div = 1000, En = true },     // AF
+            // CH3 (0x3EA): OilTemp(6-7)
+            new { Ch = 3, Byte = 6, Size = 2, Type = "S", End = "B", Var = 4, Mul = 1000, Div = 10000, En = true },   // NUM3 (OilTemp)
+            // CH4 (0x3EB): OilPressure(0-1), BattV(6-7)
+            new { Ch = 4, Byte = 0, Size = 2, Type = "U", End = "B", Var = 6, Mul = 1, Div = 1000, En = true },       // NUM5 (OilP)
+            new { Ch = 4, Byte = 6, Size = 2, Type = "U", End = "B", Var = 7, Mul = 1000, Div = 10000, En = true },   // NUM6 (BattV)
+        };
+
+        for (int i = 0; i < 8; i++)
+        {
+            var d = defaults[i];
+            _canFields.Add(new CanFieldItem
+            {
+                Index = i,
+                Channel = d.Ch,
+                StartByte = d.Byte,
+                ByteCount = d.Size,
+                DataType = d.Type,
+                Endian = d.End,
+                TargetVar = d.Var,
+                Multiplier = d.Mul,
+                Divisor = d.Div,
+                Enabled = d.En
+            });
+        }
+
+        CanFieldsGrid.DataContext = _canFieldsContext;
+        CanFieldsGrid.ItemsSource = _canFields;
+        
+        // セル編集終了時のバリデーションハンドラを登録
+        CanFieldsGrid.CellEditEnding += CanFieldsGrid_CellEditEnding;
+    }
+
+    /// <summary>
+    /// DataGridのセル編集終了時に数値バリデーションを行う
+    /// </summary>
+    private void CanFieldsGrid_CellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)
+    {
+        // キャンセル時は何もしない
+        if (e.EditAction == DataGridEditAction.Cancel)
+            return;
+
+        // 編集要素がTextBoxの場合のみ検証
+        if (e.EditingElement is not TextBox textBox)
+            return;
+
+        // 列名を取得
+        var columnHeader = e.Column.Header?.ToString();
+        if (string.IsNullOrEmpty(columnHeader))
+            return;
+
+        // 数値列のみバリデーション
+        var numericColumns = new[] { "CH", "Byte", "Size", "Off", "Mul", "Div" };
+        if (!numericColumns.Contains(columnHeader))
+            return;
+
+        var inputText = textBox.Text.Trim();
+
+        // 空文字列チェック
+        if (string.IsNullOrEmpty(inputText))
+        {
+            MessageBox.Show(
+                this,
+                $"{columnHeader}フィールドには数値を入力してください。",
+                "入力エラー",
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
+            e.Cancel = true;
+            return;
+        }
+
+        // 整数パースチェック
+        if (!int.TryParse(inputText, out int value))
+        {
+            MessageBox.Show(
+                this,
+                $"{columnHeader}フィールドには整数を入力してください。\n入力値: {inputText}",
+                "入力エラー",
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
+            e.Cancel = true;
+            return;
+        }
+
+        // 列ごとの範囲チェック
+        string? rangeError = columnHeader switch
+        {
+            "CH" when value < 1 || value > 6 => "CH は 1～6 の範囲で入力してください。",
+            "Byte" when value < 0 || value > 7 => "Byte は 0～7 の範囲で入力してください。",
+            "Size" when value != 1 && value != 2 && value != 4 => "Size は 1, 2, 4 のいずれかを入力してください。",
+            "Mul" when value <= 0 => "Mul は 1 以上の値を入力してください。",
+            "Div" when value <= 0 => "Div は 1 以上の値を入力してください。",
+            _ => null
+        };
+
+        if (rangeError != null)
+        {
+            MessageBox.Show(
+                this,
+                rangeError,
+                "入力エラー",
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
+            e.Cancel = true;
+        }
     }
 
     private void Window_Closing(object sender, CancelEventArgs e)
@@ -81,4 +298,373 @@ public partial class MainWindow : Window
             // ブラウザで開けなかった場合は無視
         }
     }
+
+    #region CAN設定
+
+    private void UpdateCanStatus(string message)
+    {
+        CanStatusText.Text = $"[{DateTime.Now:HH:mm:ss}] {message}";
+    }
+
+    /// <summary>
+    /// パラメータモードに入ってからコマンドを送信
+    /// </summary>
+    private async Task SendCanCommandAsync(ViewModels.MainViewModel vm, string command)
+    {
+        // パラメータモードに入る（空コマンドでウェイク）
+        vm.SendCommandDirect("");
+        await Task.Delay(300);
+
+        // コマンド送信
+        vm.SendCommandDirect(command);
+    }
+
+    private async void CanReadButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is ViewModels.MainViewModel vm && vm.IsConnected)
+        {
+            vm.IsBusy = true;
+            UpdateCanStatus("CAN設定を読み込み中...");
+
+            try
+            {
+                // パラメータモードに入る
+                vm.ClearResponseBuffer();
+                vm.SendCommandDirect("");
+                await Task.Delay(300);
+
+                // バッファをクリアして安定するまで待つ
+                vm.ClearResponseBuffer();
+                await Task.Delay(100);
+
+                // can_listを送信（プロンプトが来るまで待機）
+                var response = await vm.SendCommandAndGetResponseAsync("can_list", 5000);
+
+                // 応答を解析してUIに反映
+                int chCount = ParseCanConfigResponse(response);
+
+                // パラメータモードを抜ける
+                vm.ClearResponseBuffer();
+                vm.SendCommandDirect("exit");
+                await Task.Delay(200);
+
+                if (string.IsNullOrWhiteSpace(response))
+                {
+                    UpdateCanStatus("エラー: 応答がありません");
+                    return;
+                }
+
+                UpdateCanStatus($"読み込み完了: {chCount}件のデータを反映");
+            }
+            finally
+            {
+                vm.IsBusy = false;
+            }
+        }
+        else
+        {
+            UpdateCanStatus("エラー: デバイスに接続してください");
+        }
+    }
+
+    /// <summary>
+    /// can_listの応答を解析してUIに反映
+    /// </summary>
+    private int ParseCanConfigResponse(string response)
+    {
+        int matchCount = 0;
+
+        // チャンネル設定を解析: CH1: ID=0x3E8, ON
+        var chRegex = new Regex(@"CH(\d+):\s*ID=0x([0-9A-Fa-f]+),\s*(ON|OFF)", RegexOptions.IgnoreCase);
+        var chMatches = chRegex.Matches(response);
+
+        var channelBoxes = new (TextBox idBox, CheckBox enableBox)[] {
+            (CanCh1IdBox, CanCh1EnabledBox),
+            (CanCh2IdBox, CanCh2EnabledBox),
+            (CanCh3IdBox, CanCh3EnabledBox),
+            (CanCh4IdBox, CanCh4EnabledBox),
+            (CanCh5IdBox, CanCh5EnabledBox),
+            (CanCh6IdBox, CanCh6EnabledBox)
+        };
+
+        foreach (Match match in chMatches)
+        {
+            int chNum = int.Parse(match.Groups[1].Value);
+            string canId = match.Groups[2].Value;
+            bool enabled = match.Groups[3].Value.Equals("ON", StringComparison.OrdinalIgnoreCase);
+
+            if (chNum >= 1 && chNum <= 6)
+            {
+                channelBoxes[chNum - 1].idBox.Text = $"0x{canId}";
+                channelBoxes[chNum - 1].enableBox.IsChecked = enabled;
+                matchCount++;
+            }
+        }
+
+        // フィールド設定を解析
+        // ファームウェア出力: "%2d %2d   %d   %d   %c    %c   %-5s %4d %5d %5d"
+        // 例: " 3  2   0   2   S    B   NUM1     0  1000 10000"
+        // より緩い正規表現で対応（複数空白OK）
+        var fieldRegex = new Regex(@"(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+([US])\s+([BL])\s+(\S+)\s+(\d+)\s+(\d+)\s+(\d+)", RegexOptions.IgnoreCase);
+        var fieldMatches = fieldRegex.Matches(response);
+
+        // 一旦全フィールドを無効化
+        foreach (var field in _canFields)
+        {
+            field.Enabled = false;
+        }
+
+        foreach (Match match in fieldMatches)
+        {
+            int index = int.Parse(match.Groups[1].Value);
+            if (index >= 0 && index < _canFields.Count)
+            {
+                var field = _canFields[index];
+                field.Channel = int.Parse(match.Groups[2].Value);
+                field.StartByte = int.Parse(match.Groups[3].Value);
+                field.ByteCount = int.Parse(match.Groups[4].Value);
+                field.DataType = match.Groups[5].Value;
+                field.Endian = match.Groups[6].Value;
+                // Groups[7] = Var名 → 数値に変換
+                string varName = match.Groups[7].Value;
+                field.TargetVar = VarNameToIndex.TryGetValue(varName, out int varIdx) ? varIdx : 255;
+                // Groups[8] = Offset
+                field.Offset = int.Parse(match.Groups[8].Value);
+                field.Multiplier = int.Parse(match.Groups[9].Value);
+                field.Divisor = int.Parse(match.Groups[10].Value);
+                // channel > 0 なら有効（ファームウェアはchannel=0のフィールドは出力しないが念のため）
+                field.Enabled = field.Channel > 0;
+                matchCount++;
+            }
+        }
+
+        return matchCount;
+    }
+
+    /// <summary>
+    /// CAN設定のバリデーション
+    /// </summary>
+    private bool ValidateCanSettings(out string errorMessage)
+    {
+        errorMessage = "";
+        var errors = new List<string>();
+
+        // チャンネル設定のバリデーション
+        var channelBoxes = new[] {
+            (CanCh1IdBox, "CH1"),
+            (CanCh2IdBox, "CH2"),
+            (CanCh3IdBox, "CH3"),
+            (CanCh4IdBox, "CH4"),
+            (CanCh5IdBox, "CH5"),
+            (CanCh6IdBox, "CH6")
+        };
+
+        foreach (var (idBox, name) in channelBoxes)
+        {
+            if (!string.IsNullOrEmpty(idBox.Text))
+            {
+                var canId = ParseCanId(idBox.Text);
+                if (canId < 0 || canId > 0x7FF)
+                {
+                    errors.Add($"{name}: CAN IDは0x000〜0x7FFの範囲で指定してください");
+                }
+            }
+        }
+
+        // フィールド設定のバリデーション
+        foreach (var field in _canFields)
+        {
+            if (!field.Enabled) continue; // 無効なフィールドはスキップ
+
+            var idx = field.Index;
+
+            // チャンネル範囲チェック
+            if (field.Channel < 1 || field.Channel > 6)
+            {
+                errors.Add($"フィールド{idx}: CHは1〜6の範囲で指定してください");
+            }
+
+            // Byte位置チェック
+            if (field.StartByte < 0 || field.StartByte > 7)
+            {
+                errors.Add($"フィールド{idx}: Byteは0〜7の範囲で指定してください");
+            }
+
+            // Sizeチェック
+            if (field.ByteCount != 1 && field.ByteCount != 2 && field.ByteCount != 4)
+            {
+                errors.Add($"フィールド{idx}: Sizeは1, 2, 4のいずれかを指定してください");
+            }
+
+            // Byte + Size がデータ範囲を超えていないかチェック
+            if (field.StartByte + field.ByteCount > 8)
+            {
+                errors.Add($"フィールド{idx}: Byte({field.StartByte}) + Size({field.ByteCount}) が8を超えています");
+            }
+
+            // Mul/Divチェック
+            if (field.Multiplier <= 0)
+            {
+                errors.Add($"フィールド{idx}: Mulは1以上を指定してください");
+            }
+            if (field.Divisor <= 0)
+            {
+                errors.Add($"フィールド{idx}: Divは1以上を指定してください");
+            }
+        }
+
+        if (errors.Count > 0)
+        {
+            errorMessage = string.Join("\n", errors);
+            return false;
+        }
+
+        return true;
+    }
+
+    private async void CanWriteButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is not ViewModels.MainViewModel vm || !vm.IsConnected)
+        {
+            UpdateCanStatus("エラー: デバイスに接続してください");
+            return;
+        }
+
+        // バリデーション
+        if (!ValidateCanSettings(out var errorMessage))
+        {
+            MessageBox.Show($"入力値に問題があります:\n\n{errorMessage}", "入力エラー", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        vm.IsBusy = true;
+
+        try
+        {
+            var commands = new List<string>();
+
+            // CANチャンネル設定
+            var channelBoxes = new[] {
+                (CanCh1IdBox, CanCh1EnabledBox),
+                (CanCh2IdBox, CanCh2EnabledBox),
+                (CanCh3IdBox, CanCh3EnabledBox),
+                (CanCh4IdBox, CanCh4EnabledBox),
+                (CanCh5IdBox, CanCh5EnabledBox),
+                (CanCh6IdBox, CanCh6EnabledBox)
+            };
+
+            for (int i = 0; i < channelBoxes.Length; i++)
+            {
+                var (idBox, enabledBox) = channelBoxes[i];
+                if (!string.IsNullOrEmpty(idBox.Text))
+                {
+                    var canId = ParseCanId(idBox.Text);
+                    var enabled = enabledBox.IsChecked == true ? 1 : 0;
+                    // can_ch <n> <id> <en> (n=1-6)
+                    commands.Add($"can_ch {i + 1} {canId} {enabled}");
+                }
+            }
+
+            // CANフィールド設定（ENオフの場合はchannel=0で無効化）
+            foreach (var field in _canFields)
+            {
+                var dataType = field.DataType == "S" ? 1 : 0;
+                var endian = field.Endian == "L" ? 1 : 0;
+                // ENオフの場合はchannel=0で無効化
+                var channel = field.Enabled ? field.Channel : 0;
+                // can_field <n> <ch> <byte> <len> <type> <end> <var> <off> <mul> <div>
+                commands.Add($"can_field {field.Index} {channel} {field.StartByte} {field.ByteCount} {dataType} {endian} {field.TargetVar} {field.Offset} {field.Multiplier} {field.Divisor}");
+            }
+
+            if (commands.Count == 0)
+            {
+                UpdateCanStatus("設定するCAN項目がありません（ENを有効にしてください）");
+                return;
+            }
+
+            // パラメータモードに入ってからコマンドを順番に送信
+            UpdateCanStatus($"送信中: {commands.Count}個のコマンド...");
+
+            // パラメータモードに入る
+            vm.SendCommandDirect("");
+            await Task.Delay(300);
+
+            foreach (var cmd in commands)
+            {
+                vm.SendCommandDirect(cmd);
+                await Task.Delay(150);
+            }
+
+            // パラメータモードを抜ける
+            vm.SendCommandDirect("exit");
+            await Task.Delay(300);
+
+            UpdateCanStatus($"完了: {commands.Count}個のCAN設定を送信");
+        }
+        finally
+        {
+            vm.IsBusy = false;
+        }
+    }
+
+    private void CanDefaultButton_Click(object sender, RoutedEventArgs e)
+    {
+        var result = MessageBox.Show("CAN設定を出荷時設定に戻しますか？", "確認", MessageBoxButton.YesNo, MessageBoxImage.Question);
+        if (result == MessageBoxResult.Yes)
+        {
+            // チャンネル設定をデフォルトに
+            CanCh1IdBox.Text = "0x3E8"; CanCh1EnabledBox.IsChecked = true;
+            CanCh2IdBox.Text = "0x3E9"; CanCh2EnabledBox.IsChecked = true;
+            CanCh3IdBox.Text = "0x3EA"; CanCh3EnabledBox.IsChecked = true;
+            CanCh4IdBox.Text = "0x3EB"; CanCh4EnabledBox.IsChecked = true;
+            CanCh5IdBox.Text = "0x3EC"; CanCh5EnabledBox.IsChecked = true;
+            CanCh6IdBox.Text = "0x3ED"; CanCh6EnabledBox.IsChecked = false;
+
+            // フィールド設定を再初期化 (ファームウェアのCAN_PRESET_MOTECと同じ)
+            _canFields.Clear();
+            var defaults = new[]
+            {
+                // CH1 (0x3E8): RPM(0-1), MAP(4-5), IAT(6-7)
+                new { Ch = 1, Byte = 0, Size = 2, Type = "U", End = "B", Var = 10, Mul = 1000, Div = 1000, En = true },   // REV
+                new { Ch = 1, Byte = 4, Size = 2, Type = "U", End = "B", Var = 4, Mul = 1000, Div = 10000, En = true },   // NUM4 (MAP)
+                new { Ch = 1, Byte = 6, Size = 2, Type = "S", End = "B", Var = 2, Mul = 1000, Div = 10000, En = true },   // NUM2 (IAT)
+                // CH2 (0x3E9): ECT(0-1), AFR(2-3)
+                new { Ch = 2, Byte = 0, Size = 2, Type = "S", End = "B", Var = 1, Mul = 1000, Div = 10000, En = true },   // NUM1 (WaterTemp)
+                new { Ch = 2, Byte = 2, Size = 2, Type = "U", End = "B", Var = 11, Mul = 147, Div = 1000, En = true },    // AF
+                // CH3 (0x3EA): OilTemp(6-7)
+                new { Ch = 3, Byte = 6, Size = 2, Type = "S", End = "B", Var = 3, Mul = 1000, Div = 10000, En = true },   // NUM3 (OilTemp)
+                // CH4 (0x3EB): OilPressure(0-1), BattV(6-7)
+                new { Ch = 4, Byte = 0, Size = 2, Type = "U", End = "B", Var = 12, Mul = 1, Div = 1000, En = true },      // NUM5 (OilP)
+                new { Ch = 4, Byte = 6, Size = 2, Type = "U", End = "B", Var = 13, Mul = 1000, Div = 10000, En = true },  // NUM6 (BattV)
+            };
+
+            for (int i = 0; i < 8; i++)
+            {
+                var d = defaults[i];
+                _canFields.Add(new CanFieldItem
+                {
+                    Index = i, Channel = d.Ch, StartByte = d.Byte, ByteCount = d.Size,
+                    DataType = d.Type, Endian = d.End, TargetVar = d.Var,
+                    Multiplier = d.Mul, Divisor = d.Div, Enabled = d.En
+                });
+            }
+
+            UpdateCanStatus("デフォルト値に戻しました（書込ボタンで適用）");
+        }
+    }
+
+    private static int ParseCanId(string text)
+    {
+        text = text.Trim();
+        if (text.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            if (int.TryParse(text.Substring(2), System.Globalization.NumberStyles.HexNumber, null, out int hexResult))
+                return hexResult;
+        }
+        if (int.TryParse(text, out int decResult))
+            return decResult;
+        return 0;
+    }
+
+    #endregion
 }

--- a/HostApp/FULLMONI-WIDE-Terminal/Views/ParameterEditorWindow.xaml
+++ b/HostApp/FULLMONI-WIDE-Terminal/Views/ParameterEditorWindow.xaml
@@ -5,8 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
         Title="Parameter Editor - FULLMONI-WIDE"
-        Height="600" Width="500"
-        MinHeight="500" MinWidth="450"
+        Height="700" Width="650"
+        MinHeight="600" MinWidth="600"
         Background="{StaticResource PrimaryBackgroundBrush}"
         WindowStartupLocation="CenterOwner">
 
@@ -23,121 +23,235 @@
                    Foreground="{StaticResource TextBrush}"
                    Margin="0,0,0,16"/>
 
-        <!-- Parameter Groups -->
-        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
-            <StackPanel>
+        <!-- Tab Control -->
+        <TabControl Grid.Row="1" x:Name="MainTabControl"
+                    Background="Transparent"
+                    BorderBrush="{StaticResource BorderBrush}">
 
-                <!-- Tyre Settings -->
-                <GroupBox Header="タイヤサイズ" Style="{StaticResource ModernGroupBox}">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="100"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                        </Grid.RowDefinitions>
+            <!-- 基本設定タブ -->
+            <TabItem Header="基本設定">
+                <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="8">
+                    <StackPanel>
 
-                        <TextBlock Grid.Row="0" Grid.Column="0" Text="幅 (mm):" Style="{StaticResource ModernLabel}" Margin="0,4"/>
-                        <TextBox Grid.Row="0" Grid.Column="1" x:Name="TyreWidthBox"
-                                 Style="{StaticResource ModernTextBox}" Margin="4" Width="100" HorizontalAlignment="Left"/>
-                        <TextBlock Grid.Row="0" Grid.Column="2" Text="例: 195" Foreground="Gray" VerticalAlignment="Center" Margin="8,0"/>
+                        <!-- Tyre Settings -->
+                        <GroupBox Header="タイヤサイズ" Style="{StaticResource ModernGroupBox}">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="100"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Row="1" Grid.Column="0" Text="扁平率 (%):" Style="{StaticResource ModernLabel}" Margin="0,4"/>
-                        <TextBox Grid.Row="1" Grid.Column="1" x:Name="TyreAspectBox"
-                                 Style="{StaticResource ModernTextBox}" Margin="4" Width="100" HorizontalAlignment="Left"/>
-                        <TextBlock Grid.Row="1" Grid.Column="2" Text="例: 55" Foreground="Gray" VerticalAlignment="Center" Margin="8,0"/>
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="幅 (mm):" Style="{StaticResource ModernLabel}" Margin="0,4"/>
+                                <TextBox Grid.Row="0" Grid.Column="1" x:Name="TyreWidthBox"
+                                         Style="{StaticResource ModernTextBox}" Margin="4" Width="100" HorizontalAlignment="Left"/>
+                                <TextBlock Grid.Row="0" Grid.Column="2" Text="例: 195" Foreground="Gray" VerticalAlignment="Center" Margin="8,0"/>
 
-                        <TextBlock Grid.Row="2" Grid.Column="0" Text="リム (inch):" Style="{StaticResource ModernLabel}" Margin="0,4"/>
-                        <TextBox Grid.Row="2" Grid.Column="1" x:Name="TyreRimBox"
-                                 Style="{StaticResource ModernTextBox}" Margin="4" Width="100" HorizontalAlignment="Left"/>
-                        <TextBlock Grid.Row="2" Grid.Column="2" Text="例: 16" Foreground="Gray" VerticalAlignment="Center" Margin="8,0"/>
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="扁平率 (%):" Style="{StaticResource ModernLabel}" Margin="0,4"/>
+                                <TextBox Grid.Row="1" Grid.Column="1" x:Name="TyreAspectBox"
+                                         Style="{StaticResource ModernTextBox}" Margin="4" Width="100" HorizontalAlignment="Left"/>
+                                <TextBlock Grid.Row="1" Grid.Column="2" Text="例: 55" Foreground="Gray" VerticalAlignment="Center" Margin="8,0"/>
 
-                        <TextBlock Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3" x:Name="TyreSizePreview"
-                                   Text="プレビュー: 195/55 R16" Foreground="{StaticResource AccentBrush}"
-                                   FontWeight="Bold" Margin="0,8,0,0"/>
-                    </Grid>
-                </GroupBox>
+                                <TextBlock Grid.Row="2" Grid.Column="0" Text="リム (inch):" Style="{StaticResource ModernLabel}" Margin="0,4"/>
+                                <TextBox Grid.Row="2" Grid.Column="1" x:Name="TyreRimBox"
+                                         Style="{StaticResource ModernTextBox}" Margin="4" Width="100" HorizontalAlignment="Left"/>
+                                <TextBlock Grid.Row="2" Grid.Column="2" Text="例: 16" Foreground="Gray" VerticalAlignment="Center" Margin="8,0"/>
 
-                <!-- Gear Ratios -->
-                <GroupBox Header="ギア比 (x1000で入力)" Style="{StaticResource ModernGroupBox}" Margin="0,8,0,0">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="80"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="80"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                        </Grid.RowDefinitions>
+                                <TextBlock Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3" x:Name="TyreSizePreview"
+                                           Text="プレビュー: 195/55 R16" Foreground="{StaticResource AccentBrush}"
+                                           FontWeight="Bold" Margin="0,8,0,0"/>
+                            </Grid>
+                        </GroupBox>
 
-                        <TextBlock Grid.Row="0" Grid.Column="0" Text="1速:" Style="{StaticResource ModernLabel}" Margin="0,4"/>
-                        <TextBox Grid.Row="0" Grid.Column="1" x:Name="Gear1Box" Style="{StaticResource ModernTextBox}" Margin="4"/>
+                        <!-- Gear Ratios -->
+                        <GroupBox Header="ギア比 (x1000で入力)" Style="{StaticResource ModernGroupBox}" Margin="0,8,0,0">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="80"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="80"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Row="0" Grid.Column="2" Text="2速:" Style="{StaticResource ModernLabel}" Margin="8,4,0,4"/>
-                        <TextBox Grid.Row="0" Grid.Column="3" x:Name="Gear2Box" Style="{StaticResource ModernTextBox}" Margin="4"/>
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="1速:" Style="{StaticResource ModernLabel}" Margin="0,4"/>
+                                <TextBox Grid.Row="0" Grid.Column="1" x:Name="Gear1Box" Style="{StaticResource ModernTextBox}" Margin="4"/>
 
-                        <TextBlock Grid.Row="1" Grid.Column="0" Text="3速:" Style="{StaticResource ModernLabel}" Margin="0,4"/>
-                        <TextBox Grid.Row="1" Grid.Column="1" x:Name="Gear3Box" Style="{StaticResource ModernTextBox}" Margin="4"/>
+                                <TextBlock Grid.Row="0" Grid.Column="2" Text="2速:" Style="{StaticResource ModernLabel}" Margin="8,4,0,4"/>
+                                <TextBox Grid.Row="0" Grid.Column="3" x:Name="Gear2Box" Style="{StaticResource ModernTextBox}" Margin="4"/>
 
-                        <TextBlock Grid.Row="1" Grid.Column="2" Text="4速:" Style="{StaticResource ModernLabel}" Margin="8,4,0,4"/>
-                        <TextBox Grid.Row="1" Grid.Column="3" x:Name="Gear4Box" Style="{StaticResource ModernTextBox}" Margin="4"/>
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="3速:" Style="{StaticResource ModernLabel}" Margin="0,4"/>
+                                <TextBox Grid.Row="1" Grid.Column="1" x:Name="Gear3Box" Style="{StaticResource ModernTextBox}" Margin="4"/>
 
-                        <TextBlock Grid.Row="2" Grid.Column="0" Text="5速:" Style="{StaticResource ModernLabel}" Margin="0,4"/>
-                        <TextBox Grid.Row="2" Grid.Column="1" x:Name="Gear5Box" Style="{StaticResource ModernTextBox}" Margin="4"/>
+                                <TextBlock Grid.Row="1" Grid.Column="2" Text="4速:" Style="{StaticResource ModernLabel}" Margin="8,4,0,4"/>
+                                <TextBox Grid.Row="1" Grid.Column="3" x:Name="Gear4Box" Style="{StaticResource ModernTextBox}" Margin="4"/>
 
-                        <TextBlock Grid.Row="2" Grid.Column="2" Text="6速:" Style="{StaticResource ModernLabel}" Margin="8,4,0,4"/>
-                        <TextBox Grid.Row="2" Grid.Column="3" x:Name="Gear6Box" Style="{StaticResource ModernTextBox}" Margin="4"/>
+                                <TextBlock Grid.Row="2" Grid.Column="0" Text="5速:" Style="{StaticResource ModernLabel}" Margin="0,4"/>
+                                <TextBox Grid.Row="2" Grid.Column="1" x:Name="Gear5Box" Style="{StaticResource ModernTextBox}" Margin="4"/>
 
-                        <TextBlock Grid.Row="3" Grid.Column="0" Text="ファイナル:" Style="{StaticResource ModernLabel}" Margin="0,4"/>
-                        <TextBox Grid.Row="3" Grid.Column="1" x:Name="FinalGearBox" Style="{StaticResource ModernTextBox}" Margin="4"/>
+                                <TextBlock Grid.Row="2" Grid.Column="2" Text="6速:" Style="{StaticResource ModernLabel}" Margin="8,4,0,4"/>
+                                <TextBox Grid.Row="2" Grid.Column="3" x:Name="Gear6Box" Style="{StaticResource ModernTextBox}" Margin="4"/>
 
-                        <TextBlock Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
-                                   Text="例: 3.136 → 3136" Foreground="Gray" VerticalAlignment="Center" Margin="8,4"/>
-                    </Grid>
-                </GroupBox>
+                                <TextBlock Grid.Row="3" Grid.Column="0" Text="ファイナル:" Style="{StaticResource ModernLabel}" Margin="0,4"/>
+                                <TextBox Grid.Row="3" Grid.Column="1" x:Name="FinalGearBox" Style="{StaticResource ModernTextBox}" Margin="4"/>
 
-                <!-- Warning Settings -->
-                <GroupBox Header="警告設定" Style="{StaticResource ModernGroupBox}" Margin="0,8,0,0">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="120"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                        </Grid.RowDefinitions>
+                                <TextBlock Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
+                                           Text="例: 3.136 → 3136" Foreground="Gray" VerticalAlignment="Center" Margin="8,4"/>
+                            </Grid>
+                        </GroupBox>
 
-                        <TextBlock Grid.Row="0" Grid.Column="0" Text="水温 低温警告:" Style="{StaticResource ModernLabel}" Margin="0,4"/>
-                        <TextBox Grid.Row="0" Grid.Column="1" x:Name="WaterTempLowBox"
-                                 Style="{StaticResource ModernTextBox}" Margin="4" Width="80" HorizontalAlignment="Left"/>
-                        <TextBlock Grid.Row="0" Grid.Column="2" Text="°C" Style="{StaticResource ModernLabel}" Margin="4"/>
+                        <!-- Warning Settings -->
+                        <GroupBox Header="警告設定" Style="{StaticResource ModernGroupBox}" Margin="0,8,0,0">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Row="1" Grid.Column="0" Text="水温 高温警告:" Style="{StaticResource ModernLabel}" Margin="0,4"/>
-                        <TextBox Grid.Row="1" Grid.Column="1" x:Name="WaterTempHighBox"
-                                 Style="{StaticResource ModernTextBox}" Margin="4" Width="80" HorizontalAlignment="Left"/>
-                        <TextBlock Grid.Row="1" Grid.Column="2" Text="°C" Style="{StaticResource ModernLabel}" Margin="4"/>
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="水温 低温警告:" Style="{StaticResource ModernLabel}" Margin="0,4"/>
+                                <TextBox Grid.Row="0" Grid.Column="1" x:Name="WaterTempLowBox"
+                                         Style="{StaticResource ModernTextBox}" Margin="4" Width="80" HorizontalAlignment="Left"/>
+                                <TextBlock Grid.Row="0" Grid.Column="2" Text="°C" Style="{StaticResource ModernLabel}" Margin="4"/>
 
-                        <TextBlock Grid.Row="2" Grid.Column="0" Text="燃料残量警告:" Style="{StaticResource ModernLabel}" Margin="0,4"/>
-                        <TextBox Grid.Row="2" Grid.Column="1" x:Name="FuelWarnBox"
-                                 Style="{StaticResource ModernTextBox}" Margin="4" Width="80" HorizontalAlignment="Left"/>
-                        <TextBlock Grid.Row="2" Grid.Column="2" Text="%" Style="{StaticResource ModernLabel}" Margin="4"/>
-                    </Grid>
-                </GroupBox>
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="水温 高温警告:" Style="{StaticResource ModernLabel}" Margin="0,4"/>
+                                <TextBox Grid.Row="1" Grid.Column="1" x:Name="WaterTempHighBox"
+                                         Style="{StaticResource ModernTextBox}" Margin="4" Width="80" HorizontalAlignment="Left"/>
+                                <TextBlock Grid.Row="1" Grid.Column="2" Text="°C" Style="{StaticResource ModernLabel}" Margin="4"/>
 
-            </StackPanel>
-        </ScrollViewer>
+                                <TextBlock Grid.Row="2" Grid.Column="0" Text="燃料残量警告:" Style="{StaticResource ModernLabel}" Margin="0,4"/>
+                                <TextBox Grid.Row="2" Grid.Column="1" x:Name="FuelWarnBox"
+                                         Style="{StaticResource ModernTextBox}" Margin="4" Width="80" HorizontalAlignment="Left"/>
+                                <TextBlock Grid.Row="2" Grid.Column="2" Text="%" Style="{StaticResource ModernLabel}" Margin="4"/>
+                            </Grid>
+                        </GroupBox>
+
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+            <!-- CAN設定タブ -->
+            <TabItem Header="CAN設定">
+                <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="8">
+                    <StackPanel>
+
+                        <!-- CAN Channels -->
+                        <GroupBox Header="受信チャンネル設定" Style="{StaticResource ModernGroupBox}">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="50"/>
+                                    <ColumnDefinition Width="100"/>
+                                    <ColumnDefinition Width="60"/>
+                                    <ColumnDefinition Width="50"/>
+                                    <ColumnDefinition Width="100"/>
+                                    <ColumnDefinition Width="60"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+
+                                <!-- Header -->
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="CH" FontWeight="Bold" Margin="4"/>
+                                <TextBlock Grid.Row="0" Grid.Column="1" Text="CAN ID" FontWeight="Bold" Margin="4"/>
+                                <TextBlock Grid.Row="0" Grid.Column="2" Text="有効" FontWeight="Bold" Margin="4"/>
+                                <TextBlock Grid.Row="0" Grid.Column="3" Text="CH" FontWeight="Bold" Margin="4"/>
+                                <TextBlock Grid.Row="0" Grid.Column="4" Text="CAN ID" FontWeight="Bold" Margin="4"/>
+                                <TextBlock Grid.Row="0" Grid.Column="5" Text="有効" FontWeight="Bold" Margin="4"/>
+
+                                <!-- CH1-2 -->
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="1:" Style="{StaticResource ModernLabel}" Margin="4"/>
+                                <TextBox Grid.Row="1" Grid.Column="1" x:Name="CanCh1IdBox" Style="{StaticResource ModernTextBox}" Margin="2" Text="0x3E8"/>
+                                <CheckBox Grid.Row="1" Grid.Column="2" x:Name="CanCh1EnabledBox" IsChecked="True" VerticalAlignment="Center" Margin="4"/>
+                                <TextBlock Grid.Row="1" Grid.Column="3" Text="2:" Style="{StaticResource ModernLabel}" Margin="4"/>
+                                <TextBox Grid.Row="1" Grid.Column="4" x:Name="CanCh2IdBox" Style="{StaticResource ModernTextBox}" Margin="2" Text="0x3E9"/>
+                                <CheckBox Grid.Row="1" Grid.Column="5" x:Name="CanCh2EnabledBox" IsChecked="True" VerticalAlignment="Center" Margin="4"/>
+
+                                <!-- CH3-4 -->
+                                <TextBlock Grid.Row="2" Grid.Column="0" Text="3:" Style="{StaticResource ModernLabel}" Margin="4"/>
+                                <TextBox Grid.Row="2" Grid.Column="1" x:Name="CanCh3IdBox" Style="{StaticResource ModernTextBox}" Margin="2" Text="0x3EA"/>
+                                <CheckBox Grid.Row="2" Grid.Column="2" x:Name="CanCh3EnabledBox" IsChecked="True" VerticalAlignment="Center" Margin="4"/>
+                                <TextBlock Grid.Row="2" Grid.Column="3" Text="4:" Style="{StaticResource ModernLabel}" Margin="4"/>
+                                <TextBox Grid.Row="2" Grid.Column="4" x:Name="CanCh4IdBox" Style="{StaticResource ModernTextBox}" Margin="2" Text="0x3EB"/>
+                                <CheckBox Grid.Row="2" Grid.Column="5" x:Name="CanCh4EnabledBox" IsChecked="True" VerticalAlignment="Center" Margin="4"/>
+
+                                <!-- CH5-6 -->
+                                <TextBlock Grid.Row="3" Grid.Column="0" Text="5:" Style="{StaticResource ModernLabel}" Margin="4"/>
+                                <TextBox Grid.Row="3" Grid.Column="1" x:Name="CanCh5IdBox" Style="{StaticResource ModernTextBox}" Margin="2" Text="0x3EC"/>
+                                <CheckBox Grid.Row="3" Grid.Column="2" x:Name="CanCh5EnabledBox" IsChecked="True" VerticalAlignment="Center" Margin="4"/>
+                                <TextBlock Grid.Row="3" Grid.Column="3" Text="6:" Style="{StaticResource ModernLabel}" Margin="4"/>
+                                <TextBox Grid.Row="3" Grid.Column="4" x:Name="CanCh6IdBox" Style="{StaticResource ModernTextBox}" Margin="2" Text="0x3ED"/>
+                                <CheckBox Grid.Row="3" Grid.Column="5" x:Name="CanCh6EnabledBox" IsChecked="False" VerticalAlignment="Center" Margin="4"/>
+                            </Grid>
+                        </GroupBox>
+
+                        <!-- CAN Fields -->
+                        <GroupBox Header="データフィールド定義" Style="{StaticResource ModernGroupBox}" Margin="0,8,0,0">
+                            <StackPanel>
+                                <TextBlock Text="フィールド設定 (最大8個)" Foreground="Gray" Margin="4,0,0,8"/>
+
+                                <!-- DataGrid for Fields -->
+                                <DataGrid x:Name="CanFieldsGrid"
+                                          AutoGenerateColumns="False"
+                                          CanUserAddRows="False"
+                                          CanUserDeleteRows="False"
+                                          HeadersVisibility="Column"
+                                          GridLinesVisibility="Horizontal"
+                                          Background="Transparent"
+                                          RowBackground="#2D2D30"
+                                          AlternatingRowBackground="#252526"
+                                          BorderBrush="{StaticResource BorderBrush}"
+                                          Height="250">
+                                    <DataGrid.Columns>
+                                        <DataGridTextColumn Header="#" Binding="{Binding Index}" Width="30" IsReadOnly="True"/>
+                                        <DataGridTextColumn Header="CH" Binding="{Binding Channel}" Width="40"/>
+                                        <DataGridTextColumn Header="Byte" Binding="{Binding StartByte}" Width="45"/>
+                                        <DataGridTextColumn Header="Size" Binding="{Binding ByteCount}" Width="45"/>
+                                        <DataGridTextColumn Header="Type" Binding="{Binding DataType}" Width="50"/>
+                                        <DataGridTextColumn Header="Endian" Binding="{Binding Endian}" Width="55"/>
+                                        <DataGridTextColumn Header="変数" Binding="{Binding TargetVar}" Width="45"/>
+                                        <DataGridTextColumn Header="係数" Binding="{Binding Multiplier}" Width="55"/>
+                                        <DataGridTextColumn Header="除数" Binding="{Binding Divisor}" Width="55"/>
+                                        <DataGridCheckBoxColumn Header="有効" Binding="{Binding Enabled}" Width="40"/>
+                                    </DataGrid.Columns>
+                                </DataGrid>
+
+                                <TextBlock Text="係数/除数: 1000=x1.0, 100=x0.1, 10000=x10.0  |  Type: U=Unsigned, S=Signed  |  Endian: B=Big, L=Little"
+                                           Foreground="Gray" Margin="4,8,0,0" FontSize="11"/>
+                            </StackPanel>
+                        </GroupBox>
+
+                        <!-- CAN Buttons -->
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
+                            <Button Content="CAN設定読込" Style="{StaticResource ModernButton}"
+                                    Width="100" Margin="4" Click="CanReadButton_Click"/>
+                            <Button Content="CAN設定書込" Style="{StaticResource ModernButton}"
+                                    Width="100" Margin="4" Click="CanWriteButton_Click"/>
+                        </StackPanel>
+
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+        </TabControl>
 
         <!-- Buttons -->
         <Grid Grid.Row="2" Margin="0,16,0,0">


### PR DESCRIPTION
## 概要
Issue #65 Phase 2 - CAN設定UIの完成

## 変更内容

### Terminal アプリ (FULLMONI-WIDE-Terminal)
- **CAN設定タブ追加**: チャンネル設定(CH1-6)とデータフィールド定義(最大8個)のUI
- **ComboBox選択**: Type(U/S), End(B/L), Var(REV/AF/NUM1-6/SPEED)をドロップダウン選択に変更
- **入力バリデーション**: CellEditEndingイベントで数値フィールドのリアルタイム検証
  - 非数値入力の拒否とエラーポップアップ表示
  - 範囲チェック (CH: 1-6, Byte: 0-7, Size: 1/2/4, Mul/Div: >0)
- **UIの調整**:
  - ウィンドウ幅を530pxに拡張 (DataGrid表示用)
  - デフォルト起動タブをAboutに変更
- **IsBusy プロパティ追加**: コマンド処理中の操作を無効化

### Firmware
- **can_update_rx_filters()**: HALT設定OPERATEモードで安全な実行時CAN設定更新
- **can_config_changed フラグ**: 設定が実際に変更された場合のみフィルタ更新を実行

## テスト済み
- CAN設定の読み書き動作確認
- 不正入力（非数値）時のエラー表示確認
- CAN受信が設定変更後も継続することを確認

Closes #65