### PR TITLE
chore: .NETビルド成果物をgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,5 +64,10 @@ Firmware/src/**/GUI/**
 # Android build files
 HostApp/FULLMONI-WIDE-Android/.gradle/
 HostApp/FULLMONI-WIDE-Android/local.properties
+
+# .NET build files
+**/obj/
+**/bin/
+
 # PR作成用一時ファイル
 pr_body.md


### PR DESCRIPTION
obj/とbin/フォルダをgitignoreに追加。