### PR TITLE
feat: メモリ配置の最適化 - GUIConf.oをRAM2に移動

### DIFF
--- a/Firmware/src/linker_script.ld
+++ b/Firmware/src/linker_script.ld
@@ -63,7 +63,7 @@ SECTIONS
 	{
 		*(.rodata)
 		/* fmw_op0.oのacmtcは.startup_imageセクションに配置するため除外 */
-		EXCLUDE_FILE(*fmw_op0.o) *(.rodata.*)
+		EXCLUDE_FILE(* fmw_op0.o) *(.rodata.*)
 		*(C_1)
 		*(C_2)
 		*(C)
@@ -124,8 +124,9 @@ SECTIONS
 	.bss :
 	{
 		_bss = .;
-		*(.bss)
-		*(.bss.**)
+		/* GUIConf.o はRAM2(.bss2)に配置するため除外 */
+		EXCLUDE_FILE(*GUIConf.o) *(.bss)
+		EXCLUDE_FILE(*GUIConf.o) *(.bss.**)
 		*(COMMON)
 		*(B)
 		*(B_1)
@@ -135,11 +136,14 @@ SECTIONS
 		_end = .;
 	} >RAM AT>RAM
 	/* Issue #65: CAN設定用の追加RAM領域 (高位RAM 0x00864000-0x0087FFFF) */
+	/* GUIConf.o (emWin設定、約80KB) もRAM2に配置してLow RAMの空きを確保 */
 	.bss2 :
 	{
 		_bss2 = .;
 		*(.bss2)
 		*(.bss2.*)
+		*GUIConf.o(.bss)
+		*GUIConf.o(.bss.*)
 		_ebss2 = .;
 	} >RAM2 AT>RAM2
 	.ofs1 0xFE7F5D00 : AT(0xFE7F5D00)


### PR DESCRIPTION
## 概要
GUIConf.o (emWin設定、約80KB) を高位RAM (RAM2) に移動し、Low RAMの空きを確保しました。

## 変更内容
- \linker_script.ld\: GUIConf.oのBSSセクションをRAM2に配置
  - Low RAM (.bss) から \EXCLUDE_FILE\ で除外
  - RAM2 (.bss2) に明示的に配置

## メモリ使用状況

### 変更前
| 領域 | 使用量 | 空き |
|------|--------|------|
| Low RAM | ~112KB | ~0 bytes  |
| RAM2 | 222 bytes | ~112KB |

### 変更後
| 領域 | 使用量 | 空き |
|------|--------|------|
| Low RAM | 31.9 KB | **80 KB**  |
| RAM2 | 80.2 KB | 31.8 KB |

## テスト結果
- [x] aw001: 動作確認OK
- [x] aw002: 動作確認OK
- [x] ビルド成功

## 目的
AppWizard生成のCコード仕様のため、Low RAMに余裕を持たせることでRAMとRAM2の領域を平準化。