### PR TITLE
Release v1.0.0

### DIFF
--- a/Bootloader/.settings/language.settings.xml
+++ b/Bootloader/.settings/language.settings.xml
@@ -3,7 +3,7 @@
 	<configuration id="com.renesas.cdt.managedbuild.gcc.rx.configuration.debug.update.268324655" name="HardwareDebug">
 		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="42085617914617168" id="com.renesas.cdt.managedbuild.gcc.rx.ui.languageprovider" keep-relative-paths="false" name="Renesas GCCBuildinCompilerSettings" parameter="${COMMAND} ${toolchain_flags} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="1177501121225823354" id="com.renesas.cdt.managedbuild.gcc.rx.ui.languageprovider" keep-relative-paths="false" name="Renesas GCCBuildinCompilerSettings" parameter="${COMMAND} ${toolchain_flags} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/Firmware/.settings/com.renesas.smc.generationsetting.properties
+++ b/Firmware/.settings/com.renesas.smc.generationsetting.properties
@@ -1,4 +1,4 @@
 #
-#Sun Jan 18 16:41:15 JST 2026
+#Mon Feb 02 01:05:05 JST 2026
 FirstGeneration=false
 PreGenerationPath=src/smc_gen

--- a/Firmware/.settings/com.renesas.smc.tools.swcomponent.fit.properties
+++ b/Firmware/.settings/com.renesas.smc.tools.swcomponent.fit.properties
@@ -1,4 +1,4 @@
 #
-#Sun Jan 18 16:41:15 JST 2026
+#Mon Feb 02 01:05:05 JST 2026
 GccSectionName=;;;;;;;;;;
 LibraryFileNames=emWinLib_RXv3_GCC

--- a/Firmware/.settings/language.settings.xml
+++ b/Firmware/.settings/language.settings.xml
@@ -3,7 +3,7 @@
 	<configuration id="com.renesas.cdt.managedbuild.gcc.rx.configuration.debug.update.820157942" name="HardwareDebug">
 		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="65732722466150416" id="com.renesas.cdt.managedbuild.gcc.rx.ui.languageprovider" keep-relative-paths="false" name="Renesas GCCBuildinCompilerSettings" parameter="${COMMAND} ${toolchain_flags} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="1201148225777356602" id="com.renesas.cdt.managedbuild.gcc.rx.ui.languageprovider" keep-relative-paths="false" name="Renesas GCCBuildinCompilerSettings" parameter="${COMMAND} ${toolchain_flags} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/Firmware/src/firmware_version.h
+++ b/Firmware/src/firmware_version.h
@@ -12,15 +12,15 @@
 
 /* バージョン定義 (ビルド時にカスタマイズ可能) */
 #ifndef FW_VERSION_MAJOR
-#define FW_VERSION_MAJOR    0
+#define FW_VERSION_MAJOR    1
 #endif
 
 #ifndef FW_VERSION_MINOR
-#define FW_VERSION_MINOR    1
+#define FW_VERSION_MINOR    0
 #endif
 
 #ifndef FW_VERSION_PATCH
-#define FW_VERSION_PATCH    1
+#define FW_VERSION_PATCH    0
 #endif
 
 /* バージョン文字列マクロ */

--- a/HostApp/FULLMONI-WIDE-Terminal/.vscode/tasks.json
+++ b/HostApp/FULLMONI-WIDE-Terminal/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "dotnet-build-host",
+			"type": "shell",
+			"command": "dotnet",
+			"args": [
+				"build",
+				"-c",
+				"Debug"
+			],
+			"group": "build"
+		}
+	]
+}

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,0 +1,43 @@
+﻿{
+    "schemaVersion": 1,
+    "version": "1.0.0",
+    "releaseDate": "2026-02-02",
+    "releaseNotes": "https://github.com/tomoya723/FULLMONI-WIDE/releases/tag/v1.0.0",
+    "bootloader": {
+        "version": "0.1.2",
+        "file": "Bootloader_v0.1.2.mot",
+        "size": 231944,
+        "sha256": "7075f2c54cc895bfcb61ad7b78dcf2e35c7796833aa1eeb38e4c11f43154864d"
+    },
+    "firmware": {
+        "minimumBootloaderVersion": "0.1.2",
+        "variants": [
+            {
+                "id": "aw001",
+                "name": "type1",
+                "description": "tomoya723 ver",
+                "file": "Firmware_v1.0.0_aw001.bin",
+                "thumbnail": "thumbnail_v1.0.0_aw001.png",
+                "size": 956266,
+                "sha256": "779b3b36c2227e310dcc4ed65c22c61d3bda1be6e4c2c8aef90fd0f606abe6e6"
+            },
+            {
+                "id": "aw002",
+                "name": "type2",
+                "description": "chaketek ver",
+                "file": "Firmware_v1.0.0_aw002.bin",
+                "thumbnail": "thumbnail_v1.0.0_aw002.png",
+                "size": 916782,
+                "sha256": "25530b0da6dfc5e7d56eff3091f4d47f7be4cbf91f3720d4dfb38dbc09a5aeaa"
+            }
+        ]
+    },
+    "hostApps": {
+        "windows": {
+            "version": "0.1.2",
+            "file": "FULLMONI-WIDE-Terminal-win-x64.zip",
+            "size": 73438779,
+            "sha256": "bd784feb69bc79936bef12bbe6eef77aeee5c74dbb70834f153e79f4ef7be53a"
+        }
+    }
+}


### PR DESCRIPTION
## v1.0.0 リリース

### 変更内容
- ファームウェアバージョンを v1.0.0 に更新
- release-manifest.json を v1.0.0 用に更新

### 生成ファイル
- Firmware_v1.0.0_aw001.bin (956,266 bytes)
- Firmware_v1.0.0_aw002.bin (916,782 bytes)
- thumbnail_v1.0.0_aw001.png
- thumbnail_v1.0.0_aw002.png