### PR TITLE
chore: Add Git hooks to protect linker_script.ld

### DIFF
--- a/tools/git-hooks/post-checkout
+++ b/tools/git-hooks/post-checkout
@@ -1,0 +1,14 @@
+#!/bin/sh
+# post-checkout hook: linker_script.ldを読み取り専用に設定してe2 studioによる破損を防ぐ
+
+LINKER_SCRIPT="Firmware/src/linker_script.ld"
+
+if [ -f "$LINKER_SCRIPT" ]; then
+    # 読み取り専用に設定 (Windows: attrib, Unix: chmod)
+    if command -v attrib >/dev/null 2>&1; then
+        attrib +r "$LINKER_SCRIPT"
+    else
+        chmod -w "$LINKER_SCRIPT"
+    fi
+    echo "[hook] Protected $LINKER_SCRIPT (read-only)"
+fi

--- a/tools/git-hooks/post-merge
+++ b/tools/git-hooks/post-merge
@@ -1,0 +1,14 @@
+#!/bin/sh
+# post-merge hook: linker_script.ldを読み取り専用に設定してe2 studioによる破損を防ぐ
+
+LINKER_SCRIPT="Firmware/src/linker_script.ld"
+
+if [ -f "$LINKER_SCRIPT" ]; then
+    # 読み取り専用に設定 (Windows: attrib, Unix: chmod)
+    if command -v attrib >/dev/null 2>&1; then
+        attrib +r "$LINKER_SCRIPT"
+    else
+        chmod -w "$LINKER_SCRIPT"
+    fi
+    echo "[hook] Protected $LINKER_SCRIPT (read-only)"
+fi

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -1,0 +1,28 @@
+#!/bin/sh
+# pre-commit hook: linker_script.ldの構文エラーを事前にチェック
+
+LINKER_SCRIPT="Firmware/src/linker_script.ld"
+
+# linker_script.ldがステージングされている場合のみチェック
+if git diff --cached --name-only | grep -q "$LINKER_SCRIPT"; then
+    echo "[hook] Checking $LINKER_SCRIPT for syntax errors..."
+    
+    # よくある構文エラーをチェック
+    # 1. EXCLUDE_FILE(* xxx.o) のようにスペースが入っている
+    if git show :$LINKER_SCRIPT | grep -E 'EXCLUDE_FILE\(\* +[a-zA-Z]' >/dev/null 2>&1; then
+        echo "ERROR: EXCLUDE_FILE() contains space before filename"
+        echo "       Use EXCLUDE_FILE(*file.o) not EXCLUDE_FILE(* file.o)"
+        exit 1
+    fi
+    
+    # 2. *と.oファイルが別の行に分かれている（行頭が単独の*）  
+    if git show :$LINKER_SCRIPT | grep -E '^\s+\*\s*$' >/dev/null 2>&1; then
+        echo "ERROR: Standalone '*' found on its own line"
+        echo "       File reference should be *filename.o(...) on single line"
+        exit 1
+    fi
+    
+    echo "[hook] $LINKER_SCRIPT syntax OK"
+fi
+
+exit 0

--- a/tools/setup_git_hooks.bat
+++ b/tools/setup_git_hooks.bat
@@ -1,0 +1,24 @@
+@echo off
+REM Git hooksをセットアップして linker_script.ld をe2 studioの破損から保護
+REM 
+REM このスクリプトは初回クローン後に1回実行してください
+
+cd /d "%~dp0\.."
+
+echo Setting up Git hooks...
+git config core.hooksPath tools/git-hooks
+echo Git hooks path set to: tools/git-hooks
+
+REM 現在のlinker_script.ldを読み取り専用に設定
+if exist "Firmware\src\linker_script.ld" (
+    attrib +r "Firmware\src\linker_script.ld"
+    echo Protected: Firmware\src\linker_script.ld (read-only)
+)
+
+echo.
+echo Setup complete!
+echo.
+echo NOTE: linker_script.ld is now protected from e2 studio modifications.
+echo       To edit it, temporarily remove read-only: attrib -r Firmware\src\linker_script.ld
+echo       After editing, restore protection: attrib +r Firmware\src\linker_script.ld
+pause


### PR DESCRIPTION
Add Git hooks to prevent e2 studio from corrupting linker_script.ld.