### PR TITLE
release: v1.0.1

### DIFF
--- a/Firmware/src/firmware_version.h
+++ b/Firmware/src/firmware_version.h
@@ -1,7 +1,7 @@
-/*
+﻿/*
  * firmware_version.h
  *
- * ファームウェアバージョン定義
+ * 繝輔ぃ繝ｼ繝繧ｦ繧ｧ繧｢繝舌・繧ｸ繝ｧ繝ｳ螳夂ｾｩ
  *
  *  Created on: 2026/01/07
  *      Author: FULLMONI-WIDE Project
@@ -10,7 +10,7 @@
 #ifndef FIRMWARE_VERSION_H_
 #define FIRMWARE_VERSION_H_
 
-/* バージョン定義 (ビルド時にカスタマイズ可能) */
+/* 繝舌・繧ｸ繝ｧ繝ｳ螳夂ｾｩ (繝薙Ν繝画凾縺ｫ繧ｫ繧ｹ繧ｿ繝槭う繧ｺ蜿ｯ閭ｽ) */
 #ifndef FW_VERSION_MAJOR
 #define FW_VERSION_MAJOR    1
 #endif
@@ -20,10 +20,10 @@
 #endif
 
 #ifndef FW_VERSION_PATCH
-#define FW_VERSION_PATCH    0
+#define FW_VERSION_PATCH    1
 #endif
 
-/* バージョン文字列マクロ */
+/* 繝舌・繧ｸ繝ｧ繝ｳ譁・ｭ怜・繝槭け繝ｭ */
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
 #define FW_VERSION_STRING TOSTRING(FW_VERSION_MAJOR) "." TOSTRING(FW_VERSION_MINOR) "." TOSTRING(FW_VERSION_PATCH)

--- a/HostApp/FULLMONI-WIDE-Terminal/FULLMONI-WIDE-Terminal.csproj
+++ b/HostApp/FULLMONI-WIDE-Terminal/FULLMONI-WIDE-Terminal.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -11,15 +11,15 @@
     <Description>FULLMONI-WIDE Terminal - Windows Host Application for UART communication with firmware</Description>
     <Product>FULLMONI-WIDE Terminal</Product>
     <AssemblyName>FULLMONI-WIDE-Terminal</AssemblyName>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <ApplicationIcon>Assets\FMW.ico</ApplicationIcon>
-    <!-- デフォルトはDebugビルド -->
+    <!-- 繝・ヵ繧ｩ繝ｫ繝医・Debug繝薙Ν繝・-->
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
   </PropertyGroup>
 
-  <!-- Releaseビルドを禁止 -->
+  <!-- Release繝薙Ν繝峨ｒ遖∵ｭ｢ -->
   <Target Name="PreventReleaseBuild" BeforeTargets="BeforeBuild" Condition="'$(Configuration)' == 'Release'">
-    <Error Text="Releaseビルドは禁止されています。Debugビルドを使用してください: dotnet build -c Debug" />
+    <Error Text="Release繝薙Ν繝峨・遖∵ｭ｢縺輔ｌ縺ｦ縺・∪縺吶・ebug繝薙Ν繝峨ｒ菴ｿ逕ｨ縺励※縺上□縺輔＞: dotnet build -c Debug" />
   </Target>
 
   <ItemGroup>

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,43 +1,43 @@
 ﻿{
-    "schemaVersion": 1,
-    "version": "1.0.0",
-    "releaseDate": "2026-02-02",
-    "releaseNotes": "https://github.com/tomoya723/FULLMONI-WIDE/releases/tag/v1.0.0",
-    "bootloader": {
-        "version": "0.1.2",
-        "file": "Bootloader_v0.1.2.mot",
-        "size": 231944,
-        "sha256": "7075f2c54cc895bfcb61ad7b78dcf2e35c7796833aa1eeb38e4c11f43154864d"
-    },
-    "firmware": {
-        "minimumBootloaderVersion": "0.1.2",
-        "variants": [
-            {
-                "id": "aw001",
-                "name": "type1",
-                "description": "tomoya723 ver",
-                "file": "Firmware_v1.0.0_aw001.bin",
-                "thumbnail": "thumbnail_v1.0.0_aw001.png",
-                "size": 956266,
-                "sha256": "4a416e10e3c3bec20ec1029e8ce7a37a99ddebd1d385a3188fa6b444bd88fbe0"
-            },
-            {
-                "id": "aw002",
-                "name": "type2",
-                "description": "chaketek ver",
-                "file": "Firmware_v1.0.0_aw002.bin",
-                "thumbnail": "thumbnail_v1.0.0_aw002.png",
-                "size": 916782,
-                "sha256": "f2f9b9bbea159bcf2007937e1fa543248e3c26dc058e7a6306f4bb118ca8cc88"
-            }
-        ]
-    },
-    "hostApps": {
-        "windows": {
-            "version": "0.1.2",
-            "file": "FULLMONI-WIDE-Terminal-win-x64.zip",
-            "size": 73438779,
-            "sha256": "bd784feb69bc79936bef12bbe6eef77aeee5c74dbb70834f153e79f4ef7be53a"
-        }
-    }
+    "bootloader":  {
+                       "sha256":  "7075f2c54cc895bfcb61ad7b78dcf2e35c7796833aa1eeb38e4c11f43154864d",
+                       "version":  "0.1.2",
+                       "size":  231944,
+                       "file":  "Bootloader_v0.1.2.mot"
+                   },
+    "version":  "1.0.1",
+    "hostApps":  {
+                     "windows":  {
+                                     "sha256":  "ea19d662b1b1e99a4f39ab02e89c82713f400f55e65bb3c7c265d485074904ca",
+                                     "version":  "1.0.1",
+                                     "size":  77170167,
+                                     "file":  "FULLMONI-WIDE-Terminal-win-x64.zip"
+                                 }
+                 },
+    "releaseNotes":  "https://github.com/tomoya723/FULLMONI-WIDE/releases/tag/v1.0.1",
+    "releaseDate":  "2026-02-12",
+    "schemaVersion":  1,
+    "firmware":  {
+                     "minimumBootloaderVersion":  "0.1.2",
+                     "variants":  [
+                                      {
+                                          "id":  "aw001",
+                                          "name":  "type1",
+                                          "size":  956196,
+                                          "description":  "tomoya723 ver",
+                                          "sha256":  "43069a15214080344ff5711479c810057b4d7cf4e8a9ef22f7128f86834ddeaf",
+                                          "thumbnail":  "thumbnail_v1.0.0_aw001.png",
+                                          "file":  "Firmware_v1.0.1_aw001.bin"
+                                      },
+                                      {
+                                          "id":  "aw002",
+                                          "name":  "type2",
+                                          "size":  916712,
+                                          "description":  "chaketek ver",
+                                          "sha256":  "4e783bbaa5bfde21f50d3d2ed0282544d4db1eb01d2382d40607f6c45462ca6a",
+                                          "thumbnail":  "thumbnail_v1.0.0_aw002.png",
+                                          "file":  "Firmware_v1.0.1_aw002.bin"
+                                      }
+                                  ]
+                 }
 }

--- a/tools/release.ps1
+++ b/tools/release.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     FULLMONI-WIDE リリース自動化スクリプト
 


### PR DESCRIPTION
## Release v1.0.1

- Update firmware_version.h to v1.0.1
- Update release-manifest.json
- Fix release.ps1 UTF-8 BOM encoding

GitHub Release already created: https://github.com/tomoya723/FULLMONI-WIDE/releases/tag/v1.0.1